### PR TITLE
Merge env variables as an option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Multiple files will be joined on this string. If you're processing concatenated 
 ##### `context`
 Preprocessor context.
 
-##### `merge_env`
+##### `mergeEnv`
 Merge preprocessor context with the process environment variables. Default true.
 
 ### Example #1

--- a/tasks/preprocessor.js
+++ b/tasks/preprocessor.js
@@ -18,12 +18,12 @@ module.exports = function (grunt) {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       separator: ';\n',
-      merge_env : true
+      mergeEnv : true
     });
 
     var root = options.root || grunt.util.linefeed,
       context = options.context || {};
-    if(options.merge_env){
+    if(options.mergeEnv){
         _.extend(context, process.env);
     }
 


### PR DESCRIPTION
Hi,

I ran into some issues (eval of the if statement) when the env variables are merged into the preprocessor context. I added the merge as an option that defaults to true, so that it doesn't break existing stuff.

Thanks,
