### PR TITLE
Preserve line numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-preprocessor",
   "description": "Grunt task to preprocess JS files.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "homepage": "https://github.com/STAH/grunt-preprocessor",
   "author": {
     "name": "Stanislav Lesnikov",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "preprocessor": ">= 1.0.0",
+    "preprocessor": "~1.4.0",
     "lodash": "~2.4.1"
   },
   "peerDependencies": {

--- a/tasks/preprocessor.js
+++ b/tasks/preprocessor.js
@@ -18,10 +18,12 @@ module.exports = function (grunt) {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       separator: ';\n',
+      preserveLineNumbers: false,
       mergeEnv : true
     });
 
     var root = options.root || grunt.util.linefeed,
+      preserveLineNumbers = options.preserveLineNumbers || false,
       context = options.context || {};
     if(options.mergeEnv){
         _.extend(context, process.env);
@@ -42,17 +44,17 @@ module.exports = function (grunt) {
         return grunt.file.read(filepath);
       }).join(grunt.util.normalizelf(options.separator));
 
-      var sourceCompiled = processFile(src, root, context);
+      var sourceCompiled = processFile(src, root, preserveLineNumbers, context);
 
       grunt.file.write(f.dest, sourceCompiled);
       grunt.log.write("[preprocessor] Processed " + f.dest + "\n");
     });
   });
 
-  function processFile(source, root, context) {
+  function processFile(source, root, preserveLineNumbers, context) {
     var Preprocessor = require("preprocessor");
 
-    var pp = new Preprocessor(source, root);
+    var pp = new Preprocessor(source, root, preserveLineNumbers);
 
     try {
       return pp.process(context);


### PR DESCRIPTION
I added an option to preprocessor.js to preserve line numbers as long as you don't use #include.  I'd like to access this option through grunt.